### PR TITLE
Fix undeclared recursiveMatches variable

### DIFF
--- a/code/fts_fuzzy_match.js
+++ b/code/fts_fuzzy_match.js
@@ -118,7 +118,7 @@ function fuzzyMatchRecursive(
         firstMatch = false;
       }
 
-      recursiveMatches = [];
+      const recursiveMatches = [];
       const [matched, recursiveScore] = fuzzyMatchRecursive(
         pattern,
         str,


### PR DESCRIPTION
The `recursiveMatches` variable was not declared. In non-strict environments this can work (auto-attached to `window` or `global`), but for my build system this had to be fixed first. Thanks for the library, by the way!